### PR TITLE
Add Docker support for cross-compilation of do-ssh

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.github/*
+.vscode/*
+docker/*

--- a/cross-compile.sh
+++ b/cross-compile.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# This script cross-compiles the do-ssh binary for multiple architectures and operating systems.
+
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    VERSION=$(git describe --tags --always)
+else
+    echo "Error: This script must be run in a git repository."
+    exit 1
+fi
+OSs="linux darwin"
+VERSION=$(git describe --tags --always)
+
+for GOOS in $OSs; do
+    for GOARCH in $ARCHS; do
+        docker run --rm -it \
+            -v "$PWD":/usr/src/do-ssh \
+            -e GOOS=$GOOS \
+            -e GOARCH=$GOARCH \
+            -e VERSION=$VERSION \
+            -w /usr/src/do-ssh \
+            golang:1.23 bash -c "go build -v -o do-ssh-$GOOS-$GOARCH-$VERSION"
+    done
+done

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,20 @@
+# Build stage
+FROM golang:1.23-alpine AS builder
+
+WORKDIR /usr/src/do-ssh
+
+# pre-copy/cache go.mod for pre-downloading dependencies and only redownloading them in subsequent builds if they change
+COPY go.mod go.sum ./
+RUN go mod download && go mod verify
+
+COPY . .
+RUN go build -v -o do-ssh ./...
+
+# Final stage
+FROM alpine:latest
+
+WORKDIR /root/
+
+COPY --from=builder /usr/src/do-ssh/do-ssh /usr/local/bin/do-ssh
+
+CMD ["/usr/local/bin/do-ssh"]


### PR DESCRIPTION
Introduce a Dockerfile and a cross-compilation script to facilitate building the do-ssh binary for multiple architectures and operating systems.